### PR TITLE
Expose lower level funcs, reduce total message size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ strobe-rs = "0.6.2"
 sta-rs = { git = "https://github.com/brave-experiments/sta-rs", branch = "public-api-changes" }
 rand_core = "0.6.2"
 rand = { version = "0.7" }
+bincode = "1.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,8 +130,8 @@
 //! );
 //! let output = agg_res.outputs();
 //! assert_eq!(output.len(), 2);
-//! let revealed_output = output.iter().find(|v| v.value() == vec!["hello", "world"]).unwrap();
-//! assert_eq!(revealed_output.value(), vec!["hello", "world"]);
+//! let revealed_output = output.iter().find(|v| v.value() == vec!["world"]).unwrap();
+//! assert_eq!(revealed_output.value(), vec!["world"]);
 //! assert_eq!(revealed_output.occurrences(), 10);
 //! (0..10).into_iter().for_each(|i| {
 //!   assert_eq!(revealed_output.auxiliary_data()[i], vec![i as u8; 3]);


### PR DESCRIPTION
from slack:

"So I've been playing around with different methods of reducing the nested STAR message size.
The first thing i noticed is that measurements from parent layers were duplicated in the nested layers. I made a change to only encrypt the measurement for the corresponding layer, while ensuring the randomness function concatenates information from all layers to get a randomness sample.
The second thing i noticed, was that the auxiliary portion of the ciphertext, which includes the optional aux data and the key for the next layer is encoded via JSON. This greatly increases the size for a given layer, i.e. if we wanted to encrypt a 32-byte measurement, 78-bytes of JSON data will be tacked on to the data. I switched the encoding of the aux data to use bincode (https://github.com/bincode-org/bincode), which reduced the aux data to 33 bytes.
Both of these changes brought down the message size from 6KB to 4KB. I also tested encoding the entire message with bincode, and that brought the size down to 3KB. Switching to bincode will remove the extensibility that JSON gives us, but for bandwidth savings, this may be worth it. We could version the messages if we decide to change how data is structured in the future. 3KB/message for 200M daily messages gives us 600GB network transfer per day, a 400GB savings compared to the 5KB message."