### PR TITLE
Fix randomness for nested layers

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,7 +1,9 @@
 // The `api` module consists of the client- and server-specific functions for producing
 // messages and aggregating them, respectively.
 pub use crate::internal::{key_recover, recover};
-pub use crate::internal::{NestedMessage, SerializableNestedMessage};
+pub use crate::internal::{
+  NestedMessage, PartialMeasurement, SerializableNestedMessage,
+};
 
 pub mod client {
   //! The client module wraps all API functions used by clients for

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -272,8 +272,8 @@ pub struct NestedAssociatedData {
 /// layer, plus the encryption key for decrypting the next layer.
 #[derive(Clone, Debug)]
 pub struct PartialMeasurement {
-  measurement: NestedMeasurement,
-  aux: NestedAssociatedData,
+  pub measurement: NestedMeasurement,
+  pub aux: NestedAssociatedData,
 }
 impl PartialMeasurement {
   pub fn get_next_layer_key(&self) -> &Option<Vec<u8>> {

--- a/src/randomness.rs
+++ b/src/randomness.rs
@@ -77,7 +77,7 @@ impl RequestState {
       // unblind and finalize randomness output
       let unblinded = ppoprf::Client::unblind(&result.output, &self.blinds[i]);
       ppoprf::Client::finalize(
-        self.measurement(i),
+        &self.measurement(i),
         self.epoch(),
         &unblinded,
         &mut buf,
@@ -95,8 +95,12 @@ impl RequestState {
     &self.req.points
   }
 
-  fn measurement(&self, idx: usize) -> &[u8] {
-    &self.rsf.input()[idx]
+  fn measurement(&self, idx: usize) -> Vec<u8> {
+    let mut result = Vec::new();
+    for m in &self.rsf.input()[..(idx + 1)] {
+      result.extend(m);
+    }
+    result
   }
 
   fn epoch(&self) -> u8 {


### PR DESCRIPTION
I'm noticing some message tag collision in my testing. It seems to only happen with nested layers, and not the outer most layers of messages. When aggregating some test data, I'll notice that two nested layers with different parents will have the same tag.

This PR attempts to fix that issue.