### PR TITLE
Update minimum Rust version to 1.59.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [1.58.1, stable]
+        rust: [1.59.0, stable]
         os: [ubuntu-20.04]
 
     env:


### PR DESCRIPTION
Bump the minimum supported Rust version to 1.58.1 to support dependencies which need edition 2021, and then 1.59 for a dependency which requires that. This should make the github ci build work against the current development branch of sta-rs.

Also update the checkout action and avoid running duplicate tests on non-default-branch pushes.