### PR TITLE
Derive full Eq for structs that allow it

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -18,7 +18,7 @@ const NESTED_STAR_ENCRYPTION_LABEL: &str = "nested_star_layer_encrypt";
 
 /// The `NestedMeasurement` struct provides a mechanism for submitting
 /// measurements as vectors.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct NestedMeasurement(pub Vec<SingleMeasurement>);
 impl NestedMeasurement {
   pub fn new(x_list: &[Vec<u8>]) -> Result<Self, NestedSTARError> {
@@ -88,7 +88,7 @@ impl From<Message> for SerializableMessage {
 /// layers of encrypted STAR messages that can be decrypted only if the
 /// previous message layer is decrypted and opened via the standard STAR
 /// recovery mechanism.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct NestedMessage {
   pub epoch: u8,
   pub unencrypted_layer: Message,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,7 +246,7 @@ pub mod consts {
 pub mod errors {
   use std::fmt;
 
-  #[derive(Debug, Clone, PartialEq)]
+  #[derive(Debug, Clone, Eq, PartialEq)]
   pub enum NestedSTARError {
     ShareRecoveryFailedError,
     ClientMeasurementMismatchError(String, String),


### PR DESCRIPTION
Address a clippy warning. Deriving PartialEq but not Eq is an unnecessary limitation on what callers can do with the struct.