### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @brave/star-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @brave/star-reviewers
+* @brave-experiments/star-reviewers


### PR DESCRIPTION
Point github responsibility and review at the related team within the brave organisation, to simplify access control maintenance.

Uses the same `star-reviewers` team as the main sta-rs repo.